### PR TITLE
Server improvements

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -16,19 +16,19 @@ func NewAuditEntryQueue() *AuditEntryQueue {
 }
 
 // Close closes the underlying channels
-func (q AuditEntryQueue) Close() {
+func (q *AuditEntryQueue) Close() {
 	close(q.channel)
 }
 
 // Receive returns a channel to receive AuditEntry instances from.
-func (q AuditEntryQueue) Receive() <-chan interface{} {
+func (q *AuditEntryQueue) Receive() <-chan interface{} {
 	return q.channel
 }
 
-func (q AuditEntryQueue) sendRequest(req *audit.AuditRequestEntry) {
+func (q *AuditEntryQueue) HandleRequest(req *audit.AuditRequestEntry) {
 	q.channel <- req
 }
 
-func (q AuditEntryQueue) sendResponse(res *audit.AuditResponseEntry) {
+func (q *AuditEntryQueue) HandleResponse(res *audit.AuditResponseEntry) {
 	q.channel <- res
 }

--- a/queue_test.go
+++ b/queue_test.go
@@ -6,7 +6,7 @@ func (ts *TestSuite) TestSendRequest() {
 
 	req := dummyRequest()
 	go func() {
-		q.sendRequest(req)
+		q.HandleRequest(req)
 	}()
 
 	ts.Equal(req, <-q.Receive())
@@ -18,7 +18,7 @@ func (ts *TestSuite) TestSendResponse() {
 
 	res := dummyResponse()
 	go func() {
-		q.sendResponse(res)
+		q.HandleResponse(res)
 	}()
 
 	ts.Equal(res, <-q.Receive())
@@ -30,8 +30,8 @@ func (ts *TestSuite) TestClose() {
 	req := dummyRequest()
 	res := dummyResponse()
 	go func() {
-		q.sendRequest(req)
-		q.sendResponse(res)
+		q.HandleRequest(req)
+		q.HandleResponse(res)
 		q.Close()
 	}()
 

--- a/server.go
+++ b/server.go
@@ -4,38 +4,65 @@ import (
 	"bufio"
 	"encoding/json"
 	"net"
+	"time"
 
 	"github.com/hashicorp/vault/audit"
 	log "github.com/sirupsen/logrus"
 )
 
-// Listen listens on the network and address specified.
-func Listen(network, address string) (net.Listener, error) {
-	listener, err := net.Listen(network, address)
-	if err != nil {
-		return nil, err
-	}
-
-	log.WithFields(log.Fields{"addr": listener.Addr()}).Info("Listening...")
-
-	return listener, nil
+// A Handler deals with incoming audit entries.
+type Handler interface {
+	HandleRequest(*audit.AuditRequestEntry)
+	HandleResponse(*audit.AuditResponseEntry)
 }
 
-// AcceptConnections loops forever accepting and handling connections
-func AcceptConnections(listener net.Listener, queue *AuditEntryQueue) error {
+// ListenAndServe starts a TCP listener on the given address and serves
+// requests using the given handler.
+func ListenAndServe(addr string, handler Handler) error {
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+	log.WithFields(log.Fields{"addr": listener.Addr()}).Info("Listening...")
+
+	return Serve(listener, handler)
+}
+
+// Serve loops forever accepting and handling connections.
+func Serve(listener net.Listener, handler Handler) error {
+	// net/http Server also closes the listener in Serve
+	defer closeListener(listener)
+
+	var tempDelay time.Duration // how long to sleep on accept failure
+
 	for {
 		conn, err := listener.Accept()
 		if err != nil {
+			// This logic copied from the stdlib net/http server:
+			// https://go.googlesource.com/go/+/go1.10.3/src/net/http/server.go#2777
+			if ne, ok := err.(net.Error); ok && ne.Temporary() {
+				if tempDelay == 0 {
+					tempDelay = 5 * time.Millisecond
+				} else {
+					tempDelay *= 2
+				}
+				if max := 1 * time.Second; tempDelay > max {
+					tempDelay = max
+				}
+				log.Warn("Accept error: %v; retrying in %v", err, tempDelay)
+				time.Sleep(tempDelay)
+				continue
+			}
 			return err
 		}
 
 		log.WithFields(log.Fields{"remote_addr": conn.RemoteAddr()}).Info("Accepted connection")
 
-		go handleConnection(conn, queue)
+		go handleConnection(conn, handler)
 	}
 }
 
-func handleConnection(conn net.Conn, queue *AuditEntryQueue) {
+func handleConnection(conn net.Conn, handler Handler) {
 	defer closeConnection(conn)
 
 	scanner := bufio.NewScanner(conn)
@@ -53,10 +80,10 @@ func handleConnection(conn net.Conn, queue *AuditEntryQueue) {
 
 		switch entryType {
 		case "request":
-			handleRequest(lineBytes, queue)
+			handleRequest(lineBytes, handler)
 
 		case "response":
-			handleResponse(lineBytes, queue)
+			handleResponse(lineBytes, handler)
 
 		default:
 			log.WithFields(log.Fields{"type": entryType}).Warn("Received unknown audit entry type")
@@ -75,24 +102,31 @@ func getEntryType(lineBytes []byte) (string, error) {
 	return entry.Type, err
 }
 
-func handleRequest(lineBytes []byte, queue *AuditEntryQueue) {
+func handleRequest(lineBytes []byte, handler Handler) {
 	var req audit.AuditRequestEntry
 	if err := json.Unmarshal(lineBytes, &req); err != nil {
 		log.Error("Unable to unmarshal request audit entry")
 		return
 	}
 	log.WithFields(log.Fields{"request_id": req.Request.ID}).Debug("Received request audit entry")
-	queue.sendRequest(&req)
+	handler.HandleRequest(&req)
 }
 
-func handleResponse(lineBytes []byte, queue *AuditEntryQueue) {
+func handleResponse(lineBytes []byte, handler Handler) {
 	var res audit.AuditResponseEntry
 	if err := json.Unmarshal(lineBytes, &res); err != nil {
 		log.Error("Unable to unmarshal response audit entry")
 		return
 	}
 	log.WithFields(log.Fields{"request_id": res.Request.ID}).Debug("Received response audit entry")
-	queue.sendResponse(&res)
+	handler.HandleResponse(&res)
+}
+
+func closeListener(listener net.Listener) {
+	if err := listener.Close(); err != nil {
+		log.Warn("Listening not stopped cleanly", err)
+	}
+	log.WithFields(log.Fields{"addr": listener.Addr()}).Info("Stopped listening")
 }
 
 func closeConnection(conn net.Conn) {

--- a/server.go
+++ b/server.go
@@ -49,7 +49,7 @@ func Serve(listener net.Listener, handler Handler) error {
 				if max := 1 * time.Second; tempDelay > max {
 					tempDelay = max
 				}
-				log.Warn("Accept error: %v; retrying in %v", err, tempDelay)
+				log.Warnf("Accept error: %v; retrying in %v", err, tempDelay)
 				time.Sleep(tempDelay)
 				continue
 			}

--- a/server.go
+++ b/server.go
@@ -64,7 +64,7 @@ func handleConnection(conn net.Conn, handler Handler) {
 		log.Debug("Line received")
 
 		entryType, err := getEntryType(lineBytes)
-		if err != nil {
+		if err != nil || entryType == "" {
 			log.WithFields(log.Fields{"line": scanner.Text()}).Error("Unable to determine audit entry type")
 			return
 		}
@@ -80,6 +80,10 @@ func handleConnection(conn net.Conn, handler Handler) {
 		default:
 			log.WithFields(log.Fields{"type": entryType}).Warn("Received unknown audit entry type")
 		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Warn("Error scanning line", err)
 	}
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -4,9 +4,41 @@ import (
 	"encoding/json"
 	"io"
 	"net"
+	"testing"
 
 	"github.com/hashicorp/vault/audit"
+	"github.com/stretchr/testify/suite"
 )
+
+// See helper_for_test.go for common infrastructure and tools.
+
+// ServerTests is a testify test suite object that we can attach helper methods
+// to.
+type ServerTests struct{ TestSuite }
+
+// TestServer is a standard Go test function that runs our test suite's tests.
+func TestServer(t *testing.T) { suite.Run(t, new(ServerTests)) }
+
+func (ts *ServerTests) writeJSONLine(writer io.Writer, v interface{}) {
+	b, err := json.Marshal(v)
+	ts.NoError(err)
+	ts.writeLine(writer, b)
+}
+
+func (ts *ServerTests) writeStringLine(writer io.Writer, line string) {
+	ts.write(writer, []byte(line), []byte{'\n'})
+}
+
+func (ts *ServerTests) writeLine(writer io.Writer, line []byte) {
+	ts.write(writer, line, []byte{'\n'})
+}
+
+func (ts *ServerTests) write(writer io.Writer, bytes ...[]byte) {
+	for _, b := range bytes {
+		_, err := writer.Write(b)
+		ts.NoError(err)
+	}
+}
 
 type auditEntryCollector struct {
 	requests  []*audit.AuditRequestEntry
@@ -28,27 +60,13 @@ func (col *auditEntryCollector) HandleResponse(res *audit.AuditResponseEntry) {
 	col.responses = append(col.responses, res)
 }
 
-func writeJSONLine(v interface{}, writer io.Writer) {
-	b, _ := json.Marshal(v)
-	writeLine(b, writer)
-}
-
-func writeStringLine(s string, writer io.Writer) {
-	writeLine([]byte(s), writer)
-}
-
-func writeLine(b []byte, writer io.Writer) {
-	_, _ = writer.Write(b)
-	_, _ = writer.Write([]byte{'\n'})
-}
-
-func (ts *TestSuite) TestHandleRequest() {
+func (ts *ServerTests) TestHandleRequest() {
 	server, client := net.Pipe()
 
 	req := dummyRequest()
 	go func() {
 		defer server.Close()
-		writeJSONLine(req, server)
+		ts.writeJSONLine(server, req)
 	}()
 
 	collector := newAuditEntryCollector()
@@ -58,13 +76,13 @@ func (ts *TestSuite) TestHandleRequest() {
 	ts.Equal(req, collector.requests[0])
 }
 
-func (ts *TestSuite) TestHandleResponse() {
+func (ts *ServerTests) TestHandleResponse() {
 	server, client := net.Pipe()
 
 	res := dummyResponse()
 	go func() {
 		defer server.Close()
-		writeJSONLine(res, server)
+		ts.writeJSONLine(server, res)
 	}()
 
 	collector := newAuditEntryCollector()
@@ -74,16 +92,16 @@ func (ts *TestSuite) TestHandleResponse() {
 	ts.Equal(res, collector.responses[0])
 }
 
-func (ts *TestSuite) TestUnknownTypeIgnored() {
+func (ts *ServerTests) TestUnknownTypeIgnored() {
 	server, client := net.Pipe()
 
 	req := dummyRequest()
 	res := dummyResponse()
 	go func() {
 		defer server.Close()
-		writeJSONLine(req, server)
-		writeStringLine("{\"type\": \"foo\"}", server)
-		writeJSONLine(res, server)
+		ts.writeJSONLine(server, req)
+		ts.writeStringLine(server, "{\"type\": \"foo\"}")
+		ts.writeJSONLine(server, res)
 	}()
 
 	collector := newAuditEntryCollector()
@@ -95,12 +113,12 @@ func (ts *TestSuite) TestUnknownTypeIgnored() {
 	ts.Equal(res, collector.responses[0])
 }
 
-func (ts *TestSuite) TestUnknownJSON() {
+func (ts *ServerTests) TestUnknownJSON() {
 	server, client := net.Pipe()
 	defer server.Close()
 
 	go func() {
-		writeStringLine("{\"foo\": \"bar\"}", server)
+		ts.writeStringLine(server, "{\"foo\": \"bar\"}")
 	}()
 
 	collector := newAuditEntryCollector()
@@ -110,12 +128,12 @@ func (ts *TestSuite) TestUnknownJSON() {
 	ts.Empty(collector.responses)
 }
 
-func (ts *TestSuite) TestInvalidJSON() {
+func (ts *ServerTests) TestInvalidJSON() {
 	server, client := net.Pipe()
 	defer server.Close()
 
 	go func() {
-		writeStringLine("baz", server)
+		ts.writeStringLine(server, "baz")
 	}()
 
 	collector := newAuditEntryCollector()
@@ -125,7 +143,7 @@ func (ts *TestSuite) TestInvalidJSON() {
 	ts.Empty(collector.responses)
 }
 
-func (ts *TestSuite) TestServe() {
+func (ts *ServerTests) TestServe() {
 	listener, _ := ts.WithoutError(net.Listen("tcp", "127.0.0.1:0")).(net.Listener)
 	ts.AddCleanup(func() { _ = listener.Close() })
 
@@ -148,8 +166,8 @@ func (ts *TestSuite) TestServe() {
 	res := dummyResponse()
 	go func() {
 		defer conn.Close()
-		writeJSONLine(req, conn)
-		writeJSONLine(res, conn)
+		ts.writeJSONLine(conn, req)
+		ts.writeJSONLine(conn, res)
 	}()
 
 	// Ensure they are received in the queue

--- a/server_test.go
+++ b/server_test.go
@@ -124,6 +124,10 @@ func (ts *ServerTests) TestUnknownJSON() {
 	collector := newAuditEntryCollector()
 	handleConnection(client, collector)
 
+	// Ensure we can't write anymore because the connection was closed
+	_, err := server.Write([]byte("foobar\n"))
+	ts.Error(err)
+
 	ts.Empty(collector.requests)
 	ts.Empty(collector.responses)
 }
@@ -138,6 +142,10 @@ func (ts *ServerTests) TestInvalidJSON() {
 
 	collector := newAuditEntryCollector()
 	handleConnection(client, collector)
+
+	// Ensure we can't write anymore because the connection was closed
+	_, err := server.Write([]byte("foobar\n"))
+	ts.Error(err)
 
 	ts.Empty(collector.requests)
 	ts.Empty(collector.responses)

--- a/server_test.go
+++ b/server_test.go
@@ -267,6 +267,11 @@ func (ts *ServerTests) TestListenAndServe() {
 	wg.Wait()
 }
 
+func (ts *ServerTests) TestListenAndServeInvalidAddr() {
+	err := ListenAndServe("127.0.0.1:123456", newAuditEntryCollector())
+	ts.EqualError(err, "listen tcp: address 123456: invalid port")
+}
+
 func (ts *ServerTests) TestServe() {
 	listener, _ := ts.WithoutError(net.Listen("tcp", "127.0.0.1:0")).(net.Listener)
 	ts.AddCleanup(func() { _ = listener.Close() })

--- a/server_test.go
+++ b/server_test.go
@@ -135,7 +135,9 @@ func (ts *TestSuite) TestServe() {
 	ts.AddCleanup(queue.Close)
 
 	// Start serving
-	go Serve(listener, queue)
+	go func() {
+		_ = Serve(listener, queue)
+	}()
 
 	// Dial into the server
 	addr := listener.Addr()

--- a/server_test.go
+++ b/server_test.go
@@ -91,3 +91,33 @@ func (ts *TestSuite) TestUnknownTypeIgnored() {
 	ts.Len(collector.responses, 1)
 	ts.Equal(res, collector.responses[0])
 }
+
+func (ts *TestSuite) TestUnknownJSON() {
+	server, client := net.Pipe()
+	defer server.Close()
+
+	go func() {
+		writeLine(ts, "{\"foo\": \"bar\"}", server)
+	}()
+
+	collector := newAuditEntryCollector()
+	handleConnection(client, collector)
+
+	ts.Empty(collector.requests)
+	ts.Empty(collector.responses)
+}
+
+func (ts *TestSuite) TestInvalidJSON() {
+	server, client := net.Pipe()
+	defer server.Close()
+
+	go func() {
+		writeLine(ts, "baz", server)
+	}()
+
+	collector := newAuditEntryCollector()
+	handleConnection(client, collector)
+
+	ts.Empty(collector.requests)
+	ts.Empty(collector.responses)
+}


### PR DESCRIPTION
- [x] Make the server have a similar interface to the net/http server (`Serve(net.Listener, Handler)`, `ListenAndServe(string, Handler)`.
- [x] Improve handling of errors when accepting connections (copy net/http)
- [x] Test unknown audit entry type
- [x] Test invalid lines
- [x] Handle Scanner errors
- [x] Test Serve/ListenAndServe